### PR TITLE
CLI wrapper

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
     "no-comma-dangle": 2,
     // except-parens, always
     "no-cond-assign": [2, "always"],
-    "no-console": 2,
+    "no-console": 0,
     "no-constant-condition": 2,
     "no-control-regex": 2,
     "no-debugger": 2,
@@ -108,8 +108,8 @@
     "no-mixed-requires": [1, 2],
     "no-new-require": 2,
     "no-path-concat": 2,
-    "no-process-exit": 2,
-    "no-sync": 2,
+    "no-process-exit": 0,
+    "no-sync": 0,
 
     // Stylistic Issues
     "brace-style": [2, "1tbs", { "allowSingleLine": true }],

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "env": {
     "browser": 2,
-    "node": 2,
+    "node": true,
     "mocha": 2
   },
   "globals": {

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # eslint-rules-mapper
-converts .jshintrc to eslint configuration
+
+Converts .jshintrc files to eslint configuration
+
+```sh
+node index ./path/to/.jshintrc | ./.eslintrc
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,54 @@
+var fs = require('fs');
+var _ = require('lodash');
+var map = require('./lib/jshint').map;
+
+// Parse file path to jshintrc file
+var args = process.argv.slice(2);
+var jshintFilePath = args[0];
+
+// Check if argument exists
+if (!jshintFilePath) {
+  console.log('Please specify the path to your .jshintrc file');
+  process.exit(1);
+}
+
+// Chefk if .jshintrc file exists
+if (!fs.existsSync(jshintFilePath)) {
+  console.log('The .jshintrc file specified does not exist');
+  process.exit(1);
+}
+
+// Read jshintrc file
+var jshintContents = fs.readFileSync(jshintFilePath);
+var jshintRules = JSON.parse(jshintContents);
+
+// Disable console.log statements before running this, to ensure we can pipe results only
+console.log = function noop() {};
+
+// Convert to eslint json
+var eslintResult = map(jshintRules);
+var eslintEnv = eslintResult.env;
+var eslintRules = sortObject(_.omit(eslintResult, 'env'));
+var eslintJson = {
+  env: eslintEnv,
+  rules: eslintRules
+};
+
+// Write output to stdout
+var output = JSON.stringify(eslintJson, null, 2);
+process.stdout.write(output);
+
+/**
+ * Sorts the keys in an object.
+ */
+function sortObject(obj) {
+  var keys = Object.keys(obj);
+  var sortedKeys = keys.sort();
+  var sortedObj = {};
+
+  sortedKeys.forEach(function x(key) {
+    sortedObj[key] = obj[key];
+  });
+
+  return sortedObj;
+}

--- a/lib/jshint/index.js
+++ b/lib/jshint/index.js
@@ -101,9 +101,8 @@ function map(jshintConf) {
     }
 
     console.log(key, val, eslintRule);
-    throw new Error('Unhandled jshint rule: ' + key);
+    console.log('Unhandled jshint rule: ' + key);
 
     function isEnabled(v) { return v === false ? 0 : 2; }
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "map jshint or jscs rules configs to eslint",
   "main": "app.js",
   "scripts": {
-    "test": "gulp test"
+    "test": "node test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-rules-mapper",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "map jshint or jscs rules configs to eslint",
   "main": "app.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 /*eslint no-console:0, no-inline-comments:0, max-statements:0*/
-var map = require('./lib/jshint').map;
+var map = require('../lib/jshint').map;
 
 var jshintRules = {
   bitwise: true,      // Prohibits the use of bitwise operators such as ^ (XOR), | (OR)


### PR DESCRIPTION
I wrapped the library in a command line utility. The instructions for use are in the README.

I had to make a small change to the library: it no longer throws an error for unhandled jshint rules. Instead, it just does `console.log`.

The wrapper suppresses `console.log` also so that output can be piped (e.g. to an .eslintrc file).

This makes some progress toward resolving issue #1.
