### PR TITLE
Add bin to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "node test"
   },
+  "bin": {
+    "eslint-rules-mapper": "index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:valorkin/eslint-rules-mapper.git"


### PR DESCRIPTION
If you do an `npm link` after downloading this, it should work as a CLI tool now.

```
✗ eslint-rules-mapper .jshintrc

{
  "env": {
    "jasmine": true,
    "node": true,
    "mocha": true,
    "browser": true,
    "builtin": true
  },
  "rules": {
    "block-scoped-var": 2,
    "camelcase": 2,
    "comma-style": [
      2,
      "first"
    ],
    "curly": [
      2,
      "all"
    ],
    "dot-notation": [
      2,
      {
        "allowKeywords": true
      }
    ],
    "eqeqeq": [
      2,
      "allow-null"
    ],
    "global-strict": [
      2,
      "never"
    ],
    "globals": {
      "window": true
    },
    "guard-for-in": 2,
    "max-depth": [
      2,
      3
    ],
    "max-len": [
      2,
      80,
      4
    ],
    "new-cap": 2,
    "no-bitwise": 2,
    "no-caller": 2,
    "no-cond-assign": [
      2,
      "except-parens"
    ],
    "no-debugger": 2,
    "no-empty": 2,
    "no-eval": 2,
    "no-extend-native": 2,
    "no-extra-parens": 2,
    "no-irregular-whitespace": 2,
    "no-iterator": 2,
    "no-loop-func": 2,
    "no-multi-str": 2,
    "no-new": 2,
    "no-plusplus": 2,
    "no-proto": 2,
    "no-script-url": 2,
    "no-sequences": 2,
    "no-shadow": 2,
    "no-undef": 2,
    "no-unused-vars": 0,
    "no-with": 2,
    "quotes": [
      2,
      "single"
    ],
    "valid-typeof": 2,
    "wrap-iife": [
      2,
      "inside"
    ]
  }
}
```
